### PR TITLE
Add fixing geman vowels in matcher

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -48,10 +48,12 @@ impl<'a> SimpleMatcher<'a> {
                     if rule.path.len() > path.len() {
                         continue;
                     }
-                    let part: &str = &path[..rule.path.len()];
-                    if part.eq_ignore_ascii_case(&rule.path) {
+                    let normalized : &str = &rule.path;
+
+                    if path.starts_with(normalized) {
                         return rule.allow;
                     }
+
                 }
                 true
             }


### PR DESCRIPTION
This may fix Issue #11 Panic with German vowels.
Changed slice to size to a starts_with. Seems to work. Tests are green. 
